### PR TITLE
Feat/66

### DIFF
--- a/src/main/java/com/yeo_li/yeol_post/category/CategoryService.java
+++ b/src/main/java/com/yeo_li/yeol_post/category/CategoryService.java
@@ -20,123 +20,124 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CategoryService {
 
-  private final CategoryRepository categoryRepository;
-  private final PostRepositoryFacade postRepositoryFacade;
+    private final CategoryRepository categoryRepository;
+    private final PostRepositoryFacade postRepositoryFacade;
 
-  public Category findCategoryByCategoryName(String categoryName) {
-    return categoryRepository.findCategoryByCategoryName(categoryName);
-  }
+    public Category findCategoryByCategoryName(String categoryName) {
+        return categoryRepository.findCategoryByCategoryName(categoryName);
+    }
 
-  public Category findCategoryByCategoryId(Long categoryId) {
-    return categoryRepository.findCategoryById(categoryId);
-  }
+    public Category findCategoryByCategoryId(Long categoryId) {
+        return categoryRepository.findCategoryById(categoryId);
+    }
 
-  public List<CategoryResponse> getAllCategories() {
-    List<Category> categories = categoryRepository.findAll();
+    public List<CategoryResponse> getAllCategories() {
+        List<Category> categories = categoryRepository.findAll();
 
-    List<CategoryResponse> categoryResponses = new ArrayList<>();
-    for (Category category : categories) {
-      int postCnt = postRepositoryFacade.countPostByCategory(category);
+        List<CategoryResponse> categoryResponses = new ArrayList<>();
+        for (Category category : categories) {
+            int postCnt = postRepositoryFacade.countPostByCategory(category);
 //      if (postCnt == 0) {
 //        continue;
 //      }
-      categoryResponses.add(CategoryResponse.builder()
-          .categoryId(category.getId())
-          .categoryName(category.getCategoryName())
-          .categoryDescription(category.getCategoryDescription())
-          .categoryColor(category.getCategoryColor())
-          .postCount(postCnt)
-          .build());
+            categoryResponses.add(CategoryResponse.builder()
+                .categoryId(category.getId())
+                .categoryName(category.getCategoryName())
+                .categoryDescription(category.getCategoryDescription())
+                .categoryColor(category.getCategoryColor())
+                .postCount(postCnt)
+                .build());
+        }
+
+        return categoryResponses;
     }
 
-    return categoryResponses;
-  }
 
-
-  public void saveCategory(CategoryCreateCommand command) {
-    categoryRepository.save(command.toEntity());
-  }
-
-  @Transactional
-  public void deleteCategory(Long categoryId) {
-    Category category = categoryRepository.findCategoryById(categoryId);
-
-    if (category == null) {
-      throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_FOUND);
+    public void saveCategory(CategoryCreateCommand command) {
+        categoryRepository.save(command.toEntity());
     }
 
-    if (postRepositoryFacade.existsPostByCategoryId(category)) {
-      throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_DELETABLE);
+    @Transactional
+    public void deleteCategory(Long categoryId) {
+        Category category = categoryRepository.findCategoryById(categoryId);
+
+        if (category == null) {
+            throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_FOUND);
+        }
+
+        if (postRepositoryFacade.existsPostByCategoryId(category)) {
+            throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_DELETABLE);
+        }
+
+        categoryRepository.deleteCategoryById(categoryId);
     }
 
-    categoryRepository.deleteCategoryById(categoryId);
-  }
+    @Transactional
+    public void updateCategory(Long categoryId, CategoryUpdateRequest request) {
+        Category category = categoryRepository.findCategoryById(categoryId);
 
-  @Transactional
-  public void updateCategory(Long categoryId, CategoryUpdateRequest request) {
-    Category category = categoryRepository.findCategoryById(categoryId);
+        if (category == null) {
+            throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_FOUND);
+        }
 
-    if (category == null) {
-      throw new CategoryException(CategoryExceptionType.CATEGORY_NOT_FOUND);
+        if (request.categoryName() != null) {
+            category.setCategoryName(request.categoryName());
+        }
+        if (request.categoryColor() != null) {
+            category.setCategoryColor(request.categoryColor());
+        }
+        if (request.categoryDescription() != null) {
+            category.setCategoryDescription(request.categoryDescription());
+        }
+
     }
 
-    if (request.categoryName() != null) {
-      category.setCategoryName(request.categoryName());
-    }
-    if (request.categoryColor() != null) {
-      category.setCategoryColor(request.categoryColor());
-    }
-    if (request.categoryDescription() != null) {
-      category.setCategoryDescription(request.categoryDescription());
+    public List<CategoryRecentResponse> getAllCategoryRecentPost() {
+        List<CategoryRecentResponse> categoryRecentResponses = new ArrayList<>();
+
+        List<Category> categories = categoryRepository.findAll();
+        for (Category category : categories) {
+            List<Post> posts = postRepositoryFacade.findPostsByCategory(category);
+            if (posts.isEmpty()) {
+                continue;
+            }
+            Post post = posts.getFirst();
+            PostResponse postResponse = new PostResponse(
+                post.getId(),
+                post.getTitle(),
+                post.getSummary(),
+                post.getAuthor(),
+                post.getContent(),
+                post.getViews(),
+                post.getIsPublished(),
+                post.getPublishedAt(),
+                CategoryResponse.builder()
+                    .categoryId(post.getCategory().getId())
+                    .categoryName(post.getCategory().getCategoryName())
+                    .categoryColor(post.getCategory().getCategoryColor())
+                    .categoryDescription(post.getCategory().getCategoryColor())
+                    .postCount(postRepositoryFacade.countPostByCategory(post.getCategory()))
+                    .build(),
+                toTagNames(post.getPostTags())
+            );
+            categoryRecentResponses.add(CategoryRecentResponse.builder()
+                .categoryId(category.getId())
+                .categoryName(category.getCategoryName())
+                .description(category.getCategoryDescription())
+                .categoryColor(category.getCategoryColor())
+                .postCount(postResponse.category().postCount())
+                .post(postResponse)
+                .build());
+        }
+        return categoryRecentResponses;
     }
 
-  }
-
-  public List<CategoryRecentResponse> getAllCategoryRecentPost() {
-    List<CategoryRecentResponse> categoryRecentResponses = new ArrayList<>();
-
-    List<Category> categories = categoryRepository.findAll();
-    for (Category category : categories) {
-      List<Post> posts = postRepositoryFacade.findPostsByCategory(category);
-      if (posts.isEmpty()) {
-        continue;
-      }
-      Post post = posts.getFirst();
-      PostResponse postResponse = new PostResponse(
-          post.getId(),
-          post.getTitle(),
-          post.getSummary(),
-          post.getAuthor(),
-          post.getContent(),
-          post.getIsPublished(),
-          post.getPublishedAt(),
-          CategoryResponse.builder()
-              .categoryId(post.getCategory().getId())
-              .categoryName(post.getCategory().getCategoryName())
-              .categoryColor(post.getCategory().getCategoryColor())
-              .categoryDescription(post.getCategory().getCategoryColor())
-              .postCount(postRepositoryFacade.countPostByCategory(post.getCategory()))
-              .build(),
-          toTagNames(post.getPostTags())
-      );
-      categoryRecentResponses.add(CategoryRecentResponse.builder()
-          .categoryId(category.getId())
-          .categoryName(category.getCategoryName())
-          .description(category.getCategoryDescription())
-          .categoryColor(category.getCategoryColor())
-          .postCount(postResponse.category().postCount())
-          .post(postResponse)
-          .build());
+    private List<String> toTagNames(List<PostTag> postTags) {
+        List<String> tagNames = new ArrayList<>();
+        for (PostTag postTag : postTags) {
+            tagNames.add(postTag.getTag().getTagName());
+        }
+        return tagNames;
     }
-    return categoryRecentResponses;
-  }
-
-  private List<String> toTagNames(List<PostTag> postTags) {
-    List<String> tagNames = new ArrayList<>();
-    for (PostTag postTag : postTags) {
-      tagNames.add(postTag.getTag().getTagName());
-    }
-    return tagNames;
-  }
 
 }

--- a/src/main/java/com/yeo_li/yeol_post/post/controller/PostController.java
+++ b/src/main/java/com/yeo_li/yeol_post/post/controller/PostController.java
@@ -39,95 +39,106 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Post", description = "게시물 관련 API")
 public class PostController {
 
-  private final AuthorizationService authorizationService;
-  private final PostService postService;
-  private final PostCommandFactory postCommandFactory;
+    private final AuthorizationService authorizationService;
+    private final PostService postService;
+    private final PostCommandFactory postCommandFactory;
 
-  @Operation(summary = "게시물 저장", description = "관리자가 작성한 게시물을 저장합니다.")
-  @ApiResponses({
-      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
-          description = "저장 성공"
-          , content = @Content(schema = @Schema(implementation = VoidApiResponse.class)))
-  })
-  @PostMapping
-  public ResponseEntity<ApiResponse<Void>> savePost(@AuthenticationPrincipal OAuth2User principal,
-      @RequestBody @Valid PostCreateRequest request) {
-    // 인가 사용자인지 검증
-    Map<String, Object> attributes = principal.getAttributes();
-    authorizationService.validateAdminAccess(String.valueOf(attributes.get("id")));
+    @Operation(summary = "게시물 저장", description = "관리자가 작성한 게시물을 저장합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+            description = "저장 성공"
+            , content = @Content(schema = @Schema(implementation = VoidApiResponse.class)))
+    })
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> savePost(@AuthenticationPrincipal OAuth2User principal,
+        @RequestBody @Valid PostCreateRequest request) {
+        // 인가 사용자인지 검증
+        Map<String, Object> attributes = principal.getAttributes();
+        authorizationService.validateAdminAccess(String.valueOf(attributes.get("id")));
 
-    postService.createPost(postCommandFactory.createPostCommand(request));
+        postService.createPost(postCommandFactory.createPostCommand(request));
 
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(ApiResponse.onSuccess());
-  }
-
-  @Operation(summary = "게시물 검색", description = "쿼리스트링으로 제목, 태그, 카테고리, 저자를 입력 받아 키워드와 관련된 게시물을 반환합니다.")
-  @ApiResponses({
-      @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
-          description = "검색 성공"
-          , content = @Content(schema = @Schema(implementation = ListPostResponseApiResponse.class)))
-  })
-  @GetMapping
-  public ResponseEntity<ApiResponse<List<PostResponse>>> getPostsByQueryString(
-      @RequestParam Map<String, String> params) {
-    // TODO: sibal refactoring
-    List<PostResponse> postResponses = new ArrayList<>();
-    if (params.isEmpty()) {
-      postResponses = postService.getAllPosts(); // 완료 모든 게시물 반환
-    } else if (params.containsKey("title")) { // 사용자 -> 완료 출간된 게시물만 반환
-      postResponses = postService.getPostByTitle(params.get("title"));
-    } else if (params.containsKey("tag")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
-      postResponses = postService.getPostByTag(params.get("tag"));
-    } else if (params.containsKey("category")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
-      postResponses = postService.getPostByCategory(params.get("category"));
-    } else if (params.containsKey("author")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
-      postResponses = postService.getPostByAuthor(params.get("author"));
-    } else if (params.containsKey("limit") && params.containsKey(
-        "is_published")) { // 사용자 & 관리자 -> 여기만 검사해주면 될듯
-      postResponses = postService.getPostRecent(Integer.parseInt(params.get("limit")),
-          Boolean.parseBoolean(params.get("is_published")));
-    } else if (params.containsKey("is_published")) { // 관리자
-      if (Boolean.parseBoolean(params.get("is_published"))) {
-        postResponses = postService.getAllPublishedPosts();
-      } else {
-        postResponses = postService.getAllDraftPosts();
-      }
-    } else if (params.containsKey("limit")) {
-      postResponses = postService.getPostRecent(Integer.parseInt(params.get("limit")), true);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.onSuccess());
     }
 
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(ApiResponse.onSuccess(postResponses));
+    @Operation(summary = "게시물 검색", description = "쿼리스트링으로 제목, 태그, 카테고리, 저자를 입력 받아 키워드와 관련된 게시물을 반환합니다.")
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200",
+            description = "검색 성공"
+            , content = @Content(schema = @Schema(implementation = ListPostResponseApiResponse.class)))
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<PostResponse>>> getPostsByQueryString(
+        @RequestParam Map<String, String> params) {
+        // TODO: sibal refactoring
+        List<PostResponse> postResponses = new ArrayList<>();
+        if (params.isEmpty()) {
+            postResponses = postService.getAllPosts(); // 완료 모든 게시물 반환
+        } else if (params.containsKey("title")) { // 사용자 -> 완료 출간된 게시물만 반환
+            postResponses = postService.getPostByTitle(params.get("title"));
+        } else if (params.containsKey("tag")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
+            postResponses = postService.getPostByTag(params.get("tag"));
+        } else if (params.containsKey("category")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
+            postResponses = postService.getPostByCategory(params.get("category"));
+        } else if (params.containsKey("author")) { // 사용자 -> 완료 -> 출간된 게시물만 반환
+            postResponses = postService.getPostByAuthor(params.get("author"));
+        } else if (params.containsKey("limit") && params.containsKey(
+            "is_published")) { // 사용자 & 관리자 -> 여기만 검사해주면 될듯
+            postResponses = postService.getPostRecent(Integer.parseInt(params.get("limit")),
+                Boolean.parseBoolean(params.get("is_published")));
+        } else if (params.containsKey("is_published")) { // 관리자
+            if (Boolean.parseBoolean(params.get("is_published"))) {
+                postResponses = postService.getAllPublishedPosts();
+            } else {
+                postResponses = postService.getAllDraftPosts();
+            }
+        } else if (params.containsKey("limit")) {
+            postResponses = postService.getPostRecent(Integer.parseInt(params.get("limit")), true);
+        }
 
-  }
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.onSuccess(postResponses));
 
-  @DeleteMapping("/{postId}")
-  public ResponseEntity<?> deletePost(@PathVariable("postId") int postId) {
+    }
 
-    postService.deletePostByPostId(postId);
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<?> deletePost(@PathVariable("postId") int postId) {
 
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(ApiResponse.onSuccess());
-  }
+        postService.deletePostByPostId(postId);
 
-  @PatchMapping("/{postId}")
-  public ResponseEntity<?> updatePost(
-      @AuthenticationPrincipal OAuth2User principal,
-      @PathVariable("postId") Long postId,
-      @RequestBody PostUpdateRequest request) {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.onSuccess());
+    }
 
-    // 인가 사용자인지 검증
-    Map<String, Object> attributes = principal.getAttributes();
-    authorizationService.validateAdminAccess(String.valueOf(attributes.get("id")));
+    @PatchMapping("/{postId}")
+    public ResponseEntity<ApiResponse<Void>> updatePost(
+        @AuthenticationPrincipal OAuth2User principal,
+        @PathVariable("postId") Long postId,
+        @RequestBody PostUpdateRequest request) {
 
-    postService.updatePost(postId, request);
+        // 인가 사용자인지 검증
+        Map<String, Object> attributes = principal.getAttributes();
+        authorizationService.validateAdminAccess(String.valueOf(attributes.get("id")));
 
-    return ResponseEntity
-        .status(HttpStatus.OK)
-        .body(ApiResponse.onSuccess());
-  }
+        postService.updatePost(postId, request);
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.onSuccess());
+    }
+
+    @Operation(summary = "게시물 조회수 증가", description = "게시물 조회수를 1 증가시킵니다.")
+    @PostMapping("/{postId}/views")
+    public ResponseEntity<ApiResponse<Void>> increaseViews(
+        @PathVariable("postId") Long postId
+    ) {
+        postService.increaseViewCount(postId);
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(ApiResponse.onSuccess());
+    }
 }

--- a/src/main/java/com/yeo_li/yeol_post/post/controller/PostController.java
+++ b/src/main/java/com/yeo_li/yeol_post/post/controller/PostController.java
@@ -71,7 +71,7 @@ public class PostController {
     })
     @GetMapping
     public ResponseEntity<ApiResponse<List<PostResponse>>> getPostsByQueryString(
-        @RequestParam Map<String, String> params) {
+        @RequestParam(required = false) Map<String, String> params) {
         // TODO: sibal refactoring
         List<PostResponse> postResponses = new ArrayList<>();
         if (params.isEmpty()) {

--- a/src/main/java/com/yeo_li/yeol_post/post/domain/Post.java
+++ b/src/main/java/com/yeo_li/yeol_post/post/domain/Post.java
@@ -63,4 +63,8 @@ public class Post extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostTag> postTags = new ArrayList<>();
+
+    public void increaseViewCount() {
+        this.views++;
+    }
 }

--- a/src/main/java/com/yeo_li/yeol_post/post/dto/PostResponse.java
+++ b/src/main/java/com/yeo_li/yeol_post/post/dto/PostResponse.java
@@ -30,6 +30,10 @@ public record PostResponse(
     @NotBlank
     String content,
 
+    @Schema(description = "게시물 조회수", example = "34")
+    @NotNull
+    Long views,
+
     @NotNull
     @JsonProperty("is_published")
     @Schema(description = "게시 여부", example = "true")

--- a/src/main/java/com/yeo_li/yeol_post/post/service/PostService.java
+++ b/src/main/java/com/yeo_li/yeol_post/post/service/PostService.java
@@ -124,6 +124,7 @@ public class PostService {
                 post.getSummary(),
                 post.getAuthor(),
                 post.getContent(),
+                post.getViews(),
                 post.getIsPublished(),
                 post.getPublishedAt(),
                 CategoryResponse.builder()


### PR DESCRIPTION
# 조회수 기능 구현 계획

## 1. 정의

우선, 블로그에서 **사용자가 게시물을 조회한다**는 행위의 의미를 명확히 정의해야 합니다.

제가 생각한 정의는 다음과 같습니다.

> **사용자**(로그인 여부 무관)가 블로그 게시물의 본문을 보기 위해  
> 게시물 링크를 클릭하여 `blog.yeo-li.com/posts/[id]`로 이동했을 때.

단순히 **조회수 증가 API**를 호출했다고 해서 사용자가 실제로 게시물을 조회했다고 보기는 어렵습니다.  
따라서 **정확히 해당 URL에 방문했을 때**, 해당 `id`의 게시물 조회수를 늘리도록 규정합니다.

또한, **한 사용자가 같은 게시물을 여러 번 눌러도 조회수가 증가**하도록 구현할 계획입니다.

---

## 2. 필요 API

1. **조회수 조회 API**
   - 별도의 API로 만들지 않고, 기존 `PostResponse`에 포함하여 전송합니다.
<br><br>
2. **조회수 증가 API**
   - 사용자가 `posts/[id]`에 접근했을 때 자동 실행되도록 구현합니다.

---

## 3. 주의사항

1. **프론트에서 의도치 않은 이중 호출 방지**
   - 페이지 로드/렌더링 과정에서 중복 API 호출이 발생하지 않도록 처리.
<br><br>
2. **조회 폭주 방지**
   - 특정 게시물에 대한 비정상적 요청 폭주를 감지하고 제어하는 로직 필요.