### PR TITLE
feat: 피드 기능 구현 (#125)

### DIFF
--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/controller/FeedController.java
@@ -1,0 +1,65 @@
+package com.yeo_li.yeol_post.domain.feed.controller;
+
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedCreateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedUpdateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.response.FeedResponse;
+import com.yeo_li.yeol_post.domain.feed.service.FeedService;
+import com.yeo_li.yeol_post.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/feeds")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<FeedResponse>>> getFeeds(
+        @AuthenticationPrincipal OAuth2User principal
+    ) {
+        List<FeedResponse> responses = feedService.getFeeds(principal);
+        return ResponseEntity.ok(ApiResponse.onSuccess(responses));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<FeedResponse>> saveFeed(
+        @AuthenticationPrincipal OAuth2User principal,
+        @RequestBody @Valid FeedCreateRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(feedService.saveFeed(principal, request)));
+    }
+
+    @PatchMapping("/{feedId}")
+    public ResponseEntity<ApiResponse<FeedResponse>> updateFeed(
+        @AuthenticationPrincipal OAuth2User principal,
+        @PathVariable Long feedId,
+        @RequestBody @Valid FeedUpdateRequest request
+    ) {
+        return ResponseEntity.ok(
+            ApiResponse.onSuccess(feedService.updateFeed(principal, feedId, request))
+        );
+    }
+
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<ApiResponse<Void>> deleteFeed(
+        @AuthenticationPrincipal OAuth2User principal,
+        @PathVariable Long feedId
+    ) {
+        feedService.deleteFeed(principal, feedId);
+        return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedCreateRequest.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedCreateRequest.java
@@ -1,0 +1,21 @@
+package com.yeo_li.yeol_post.domain.feed.dto.request;
+
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "피드 생성 요청")
+public record FeedCreateRequest(
+    @Schema(description = "피드 내용", example = "오늘의 짧은 기록")
+    @NotBlank(message = "피드 내용은 비어 있을 수 없습니다.")
+    @Size(max = 500, message = "피드는 500자 이하로 입력해주세요.")
+    String content,
+
+    @Schema(description = "피드 접근 권한", example = "PUBLIC")
+    @NotNull(message = "피드 접근 권한은 필수입니다.")
+    ContentAccessLevel requiredAccessLevel
+) {
+
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.yeo_li.yeol_post.domain.feed.dto.request;
+
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "피드 수정 요청")
+public record FeedUpdateRequest(
+    @Schema(description = "수정할 피드 내용", example = "수정된 짧은 기록")
+    @Size(max = 500, message = "피드는 500자 이하로 입력해주세요.")
+    String content,
+
+    @Schema(description = "수정할 피드 접근 권한", example = "LIMITED")
+    ContentAccessLevel requiredAccessLevel
+) {
+
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/response/FeedResponse.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/response/FeedResponse.java
@@ -1,0 +1,15 @@
+package com.yeo_li.yeol_post.domain.feed.dto.response;
+
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import java.time.LocalDateTime;
+
+public record FeedResponse(
+    Long feedId,
+    String authorNickname,
+    String content,
+    ContentAccessLevel requiredAccessLevel,
+    LocalDateTime createdAt,
+    boolean isOwner
+) {
+
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/Feed.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/Feed.java
@@ -1,0 +1,47 @@
+package com.yeo_li.yeol_post.domain.feed.entity;
+
+import com.yeo_li.yeol_post.domain.user.domain.User;
+import com.yeo_li.yeol_post.global.common.entity.BaseTimeEntity;
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Feed extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 500)
+    @Column(length = 500, nullable = false)
+    private String content;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ContentAccessLevel requiredAccessLevel;
+
+    private LocalDateTime deletedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/exception/FeedExceptionType.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/exception/FeedExceptionType.java
@@ -1,0 +1,46 @@
+package com.yeo_li.yeol_post.domain.feed.exception;
+
+import com.yeo_li.yeol_post.global.common.response.code.BaseCode;
+import com.yeo_li.yeol_post.global.common.response.code.Reason;
+import org.springframework.http.HttpStatus;
+
+public enum FeedExceptionType implements BaseCode {
+    FEED_CONTENT_INVALID(HttpStatus.BAD_REQUEST, "FEED400", "피드 내용이 유효하지 않습니다."),
+    FEED_ACCESS_LEVEL_INVALID(HttpStatus.BAD_REQUEST, "FEED400", "피드 접근 권한이 유효하지 않습니다."),
+    FEED_UPDATE_REQUEST_INVALID(HttpStatus.BAD_REQUEST, "FEED400", "수정할 피드 정보가 없습니다."),
+    FEED_USER_ID_INVALID(HttpStatus.UNAUTHORIZED, "FEED401", "인증된 사용자 정보를 찾을 수 없습니다."),
+    FEED_FORBIDDEN(HttpStatus.FORBIDDEN, "FEED403", "피드에 접근할 권한이 없습니다."),
+    FEED_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "사용자를 찾을 수 없습니다."),
+    FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "FEED404", "피드를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    FeedExceptionType(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public Reason getReason() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .data(null)
+            .build();
+    }
+
+    @Override
+    public Reason getReasonHttpStatus() {
+        return Reason.builder()
+            .message(message)
+            .code(code)
+            .isSuccess(false)
+            .httpStatus(httpStatus)
+            .data(null)
+            .build();
+    }
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedRepository.java
@@ -1,0 +1,28 @@
+package com.yeo_li.yeol_post.domain.feed.repository;
+
+import com.yeo_li.yeol_post.domain.feed.entity.Feed;
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+    @EntityGraph(attributePaths = "author")
+    @Query("""
+        SELECT f
+        FROM Feed f
+        WHERE f.requiredAccessLevel IN :contentAccessLevel
+          AND f.deletedAt IS NULL
+        ORDER BY f.createdAt DESC
+        """)
+    List<Feed> findAccessibleFeeds(
+        @NotNull @Param("contentAccessLevel") List<ContentAccessLevel> contentAccessLevel);
+
+    @EntityGraph(attributePaths = "author")
+    Optional<Feed> findByIdAndDeletedAtIsNull(Long id);
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/service/FeedService.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/service/FeedService.java
@@ -1,0 +1,190 @@
+package com.yeo_li.yeol_post.domain.feed.service;
+
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedCreateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedUpdateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.response.FeedResponse;
+import com.yeo_li.yeol_post.domain.feed.entity.Feed;
+import com.yeo_li.yeol_post.domain.feed.exception.FeedExceptionType;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedRepository;
+import com.yeo_li.yeol_post.domain.user.domain.User;
+import com.yeo_li.yeol_post.domain.user.repository.UserRepository;
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import com.yeo_li.yeol_post.global.common.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.safety.Safelist;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+
+    public List<FeedResponse> getFeeds(OAuth2User principal) {
+        Long userId = getUserId(principal);
+        if (userId == null) {
+            List<Feed> feeds = feedRepository.findAccessibleFeeds(
+                ContentAccessLevel.PUBLIC.accessibleLevels());
+
+            return convertFeedResponseListNoViewer(feeds);
+        }
+
+        User viewer = userRepository.findById(userId)
+            .orElseThrow(() -> new GeneralException(FeedExceptionType.FEED_USER_NOT_FOUND));
+
+        List<Feed> feeds = feedRepository.findAccessibleFeeds(
+            viewer.getContentAccessLevel().accessibleLevels());
+
+        return convertFeedResponseList(feeds, viewer);
+    }
+
+    private Long getUserId(OAuth2User principal) {
+        if (principal == null) {
+            return null;
+        }
+
+        Object userIdAttribute = principal.getAttributes().get("userId");
+        if (userIdAttribute == null) {
+            return null;
+        }
+
+        if (userIdAttribute instanceof Number userIdNumber) {
+            return userIdNumber.longValue();
+        }
+
+        if (userIdAttribute instanceof String userIdString) {
+            try {
+                return Long.parseLong(userIdString);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    private List<FeedResponse> convertFeedResponseList(List<Feed> feeds, User viewer) {
+        List<FeedResponse> feedResponses = new ArrayList<>();
+        for (Feed feed : feeds) {
+            if (feed.getDeletedAt() == null) {
+                feedResponses.add(convertFeedResponse(feed, viewer));
+            }
+        }
+        return feedResponses;
+    }
+
+    private FeedResponse convertFeedResponse(Feed feed, User user) {
+        return new FeedResponse(feed.getId(), feed.getAuthor().getNickname(), feed.getContent(),
+            feed.getRequiredAccessLevel(),
+            feed.getCreatedAt(), Objects.equals(feed.getAuthor().getId(), user.getId()));
+    }
+
+    private List<FeedResponse> convertFeedResponseListNoViewer(List<Feed> feeds) {
+        List<FeedResponse> feedResponses = new ArrayList<>();
+        for (Feed feed : feeds) {
+            if (feed.getDeletedAt() == null) {
+                feedResponses.add(convertFeedResponseNoViewer(feed));
+            }
+        }
+        return feedResponses;
+    }
+
+    private FeedResponse convertFeedResponseNoViewer(Feed feed) {
+        return new FeedResponse(feed.getId(), feed.getAuthor().getNickname(), feed.getContent(),
+            feed.getRequiredAccessLevel(), feed.getCreatedAt(), false);
+    }
+
+    @Transactional
+    public FeedResponse saveFeed(OAuth2User principal, FeedCreateRequest request) {
+        User author = getAuthenticatedUser(principal);
+
+        if (request == null || request.requiredAccessLevel() == null) {
+            throw new GeneralException(FeedExceptionType.FEED_ACCESS_LEVEL_INVALID);
+        }
+
+        Feed feed = new Feed();
+        feed.setContent(sanitizeFeedContent(request.content()));
+        feed.setRequiredAccessLevel(request.requiredAccessLevel());
+        feed.setAuthor(author);
+
+        Feed savedFeed = feedRepository.save(feed);
+        return convertFeedResponse(savedFeed, author);
+    }
+
+    @Transactional
+    public FeedResponse updateFeed(OAuth2User principal, Long feedId, FeedUpdateRequest request) {
+        User author = getAuthenticatedUser(principal);
+        Feed feed = getActiveFeed(feedId);
+        validateOwner(feed, author);
+
+        if (request == null || (request.content() == null && request.requiredAccessLevel() == null)) {
+            throw new GeneralException(FeedExceptionType.FEED_UPDATE_REQUEST_INVALID);
+        }
+
+        if (request.content() != null) {
+            feed.setContent(sanitizeFeedContent(request.content()));
+        }
+
+        if (request.requiredAccessLevel() != null) {
+            feed.setRequiredAccessLevel(request.requiredAccessLevel());
+        }
+
+        return convertFeedResponse(feed, author);
+    }
+
+    @Transactional
+    public void deleteFeed(OAuth2User principal, Long feedId) {
+        User author = getAuthenticatedUser(principal);
+        Feed feed = getActiveFeed(feedId);
+        validateOwner(feed, author);
+
+        feed.setDeletedAt(LocalDateTime.now());
+    }
+
+    private User getAuthenticatedUser(OAuth2User principal) {
+        Long userId = getUserId(principal);
+        if (userId == null) {
+            throw new GeneralException(FeedExceptionType.FEED_USER_ID_INVALID);
+        }
+
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new GeneralException(FeedExceptionType.FEED_USER_NOT_FOUND));
+    }
+
+    private Feed getActiveFeed(Long feedId) {
+        return feedRepository.findByIdAndDeletedAtIsNull(feedId)
+            .orElseThrow(() -> new GeneralException(FeedExceptionType.FEED_NOT_FOUND));
+    }
+
+    private void validateOwner(Feed feed, User viewer) {
+        if (!Objects.equals(feed.getAuthor().getId(), viewer.getId())) {
+            throw new GeneralException(FeedExceptionType.FEED_FORBIDDEN);
+        }
+    }
+
+    private String sanitizeFeedContent(String content) {
+        if (content == null) {
+            throw new GeneralException(FeedExceptionType.FEED_CONTENT_INVALID);
+        }
+
+        String sanitized = Jsoup.clean(
+            content,
+            "",
+            Safelist.none(),
+            new Document.OutputSettings().prettyPrint(false)
+        );
+        if (sanitized.isBlank()) {
+            throw new GeneralException(FeedExceptionType.FEED_CONTENT_INVALID);
+        }
+        return sanitized;
+    }
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/user/domain/User.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/user/domain/User.java
@@ -3,6 +3,7 @@ package com.yeo_li.yeol_post.domain.user.domain;
 import com.yeo_li.yeol_post.domain.post.domain.Post;
 import com.yeo_li.yeol_post.domain.subscription.domain.Subscription;
 import com.yeo_li.yeol_post.global.common.entity.BaseTimeEntity;
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
 import jakarta.annotation.Nullable;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -51,6 +52,11 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     private Role role;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ContentAccessLevel contentAccessLevel = ContentAccessLevel.PUBLIC;
 
     @Nullable
     private LocalDateTime deletedAt;

--- a/src/main/java/com/yeo_li/yeol_post/global/common/entity/ContentAccessLevel.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/common/entity/ContentAccessLevel.java
@@ -1,0 +1,7 @@
+package com.yeo_li.yeol_post.global.common.entity;
+
+public enum ContentAccessLevel {
+    PUBLIC,
+    LIMITED,
+    PRIVATE
+}

--- a/src/main/java/com/yeo_li/yeol_post/global/common/entity/ContentAccessLevel.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/common/entity/ContentAccessLevel.java
@@ -1,7 +1,22 @@
 package com.yeo_li.yeol_post.global.common.entity;
 
+import java.util.Arrays;
+import java.util.List;
+
 public enum ContentAccessLevel {
-    PUBLIC,
-    LIMITED,
-    PRIVATE
+    PUBLIC(0),
+    LIMITED(1),
+    PRIVATE(2);
+
+    private int priority;
+
+    ContentAccessLevel(int priority) {
+        this.priority = priority;
+    }
+
+    public List<ContentAccessLevel> accessibleLevels() {
+        return Arrays.stream(values())
+            .filter(level -> level.priority <= this.priority)
+            .toList();
+    }
 }

--- a/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
@@ -108,7 +108,8 @@ public class SecurityConfig {
                     "/api/v1/visitors/**",
                     "/api/v1/subscriptions/**",
                     "/api/v1/users/me",
-                    "/api/v1/likes/**"
+                    "/api/v1/likes/**",
+                    "/api/v1/feeds"
                 ).permitAll()
 
                 // public write endpoint
@@ -126,17 +127,20 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST,
                     "/api/v1/posts",
                     "/api/v1/categories",
-                    "/api/v1/images"
+                    "/api/v1/images",
+                    "/api/v1/feeds"
                 ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PATCH,
                     "/api/v1/posts/**",
                     "/api/v1/categories/**",
-                    "/api/v1/drafts/**"
+                    "/api/v1/drafts/**",
+                    "/api/v1/feeds/**"
                 ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/users/**").authenticated()
                 .requestMatchers(HttpMethod.DELETE,
                     "/api/v1/posts/**",
-                    "/api/v1/categories/**"
+                    "/api/v1/categories/**",
+                    "/api/v1/feeds/**"
                 ).hasRole("ADMIN")
                 .requestMatchers("/api/v1/**").authenticated()
                 .anyRequest().authenticated()

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,5 @@ databaseChangeLog:
       file: db/changelog/v1_0/014-create-comment-like-table.yaml
   - include:
       file: db/changelog/v1_0/015-create-comment-table.yaml
+  - include:
+      file: db/changelog/v1_0/016-create-feed-table-and-content-access-level.yaml

--- a/src/main/resources/db/changelog/v1_0/016-create-feed-table-and-content-access-level.yaml
+++ b/src/main/resources/db/changelog/v1_0/016-create-feed-table-and-content-access-level.yaml
@@ -1,0 +1,111 @@
+databaseChangeLog:
+  - changeSet:
+      id: 033-add-user-content-access-level-column
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: user }
+          - not:
+              - columnExists:
+                  tableName: user
+                  columnName: content_access_level
+      changes:
+        - addColumn:
+            tableName: user
+            columns:
+              - column:
+                  name: content_access_level
+                  type: VARCHAR(20)
+                  defaultValue: PUBLIC
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 034-create-feed-table
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        not:
+          - tableExists:
+              tableName: feed
+      changes:
+        - createTable:
+            tableName: feed
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column: { name: created_at, type: DATETIME(6) }
+              - column: { name: updated_at, type: DATETIME(6) }
+              - column:
+                  name: content
+                  type: VARCHAR(500)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: required_access_level
+                  type: VARCHAR(20)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: deleted_at
+                  type: DATETIME(6)
+              - column:
+                  name: author_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 035-create-index-feed-author-id
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed }
+          - columnExists:
+              tableName: feed
+              columnName: author_id
+          - not:
+              - indexExists:
+                  tableName: feed
+                  indexName: idx_feed_author_id
+      changes:
+        - createIndex:
+            tableName: feed
+            indexName: idx_feed_author_id
+            columns:
+              - column: { name: author_id }
+
+  - changeSet:
+      id: 036-add-fk-feed-author
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed }
+          - tableExists: { tableName: user }
+          - columnExists:
+              tableName: feed
+              columnName: author_id
+          - not:
+              - foreignKeyConstraintExists:
+                  foreignKeyName: fk_feed_author
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: feed
+            baseColumnNames: author_id
+            referencedTableName: user
+            referencedColumnNames: id
+            constraintName: fk_feed_author
+            onDelete: RESTRICT
+            onUpdate: RESTRICT

--- a/src/test/java/com/yeo_li/yeol_post/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/yeo_li/yeol_post/domain/feed/service/FeedServiceTest.java
@@ -1,0 +1,576 @@
+package com.yeo_li.yeol_post.domain.feed.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedCreateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.request.FeedUpdateRequest;
+import com.yeo_li.yeol_post.domain.feed.dto.response.FeedResponse;
+import com.yeo_li.yeol_post.domain.feed.entity.Feed;
+import com.yeo_li.yeol_post.domain.feed.exception.FeedExceptionType;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedRepository;
+import com.yeo_li.yeol_post.domain.user.domain.Role;
+import com.yeo_li.yeol_post.domain.user.domain.User;
+import com.yeo_li.yeol_post.domain.user.repository.UserRepository;
+import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
+import com.yeo_li.yeol_post.global.common.response.exception.GeneralException;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FeedRepository feedRepository;
+
+    @Mock
+    private OAuth2User principal;
+
+    @InjectMocks
+    private FeedService feedService;
+
+    @Nested
+    class GetFeedsTest {
+
+        @Test
+        void getFeeds_로그인하지않은사용자는_PUBLIC_피드만_반환한다() {
+            // given
+            List<ContentAccessLevel> accessLevels = List.of(ContentAccessLevel.PUBLIC);
+            User author = createUser(1L, ContentAccessLevel.PRIVATE);
+            Feed publicFeed = createFeed(1L, "PUBLIC 피드", ContentAccessLevel.PUBLIC, author);
+
+            when(feedRepository.findAccessibleFeeds(accessLevels))
+                .thenReturn(List.of(publicFeed));
+
+            // when
+            List<FeedResponse> responses = feedService.getFeeds(null);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses)
+                .extracting(FeedResponse::requiredAccessLevel)
+                .containsExactly(ContentAccessLevel.PUBLIC);
+            assertThat(responses.get(0).isOwner()).isFalse();
+
+            verify(feedRepository).findAccessibleFeeds(accessLevels);
+            verifyNoInteractions(userRepository);
+        }
+
+        @Test
+        void getFeeds_PUBLIC_사용자는_PUBLIC_피드만_반환한다() {
+            // given
+            List<ContentAccessLevel> accessLevels = List.of(ContentAccessLevel.PUBLIC);
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            Feed publicFeed = createFeed(1L, "PUBLIC 피드", ContentAccessLevel.PUBLIC, viewer);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findAccessibleFeeds(accessLevels))
+                .thenReturn(List.of(publicFeed));
+
+            // when
+            List<FeedResponse> responses = feedService.getFeeds(principal);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses)
+                .extracting(FeedResponse::requiredAccessLevel)
+                .containsExactly(ContentAccessLevel.PUBLIC);
+            assertThat(responses.get(0).isOwner()).isTrue();
+
+            verify(feedRepository).findAccessibleFeeds(accessLevels);
+        }
+
+        @Test
+        void getFeeds_LIMITED_사용자는_PUBLIC_LIMITED_피드를_반환한다() {
+            // given
+            List<ContentAccessLevel> accessLevels = List.of(
+                ContentAccessLevel.PUBLIC,
+                ContentAccessLevel.LIMITED
+            );
+            User viewer = createUser(10L, ContentAccessLevel.LIMITED);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed publicFeed = createFeed(1L, "PUBLIC 피드", ContentAccessLevel.PUBLIC, author);
+            Feed limitedFeed = createFeed(2L, "LIMITED 피드", ContentAccessLevel.LIMITED, viewer);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findAccessibleFeeds(accessLevels))
+                .thenReturn(List.of(limitedFeed, publicFeed));
+
+            // when
+            List<FeedResponse> responses = feedService.getFeeds(principal);
+
+            // then
+            assertThat(responses).hasSize(2);
+            assertThat(responses)
+                .extracting(FeedResponse::requiredAccessLevel)
+                .containsExactly(ContentAccessLevel.LIMITED, ContentAccessLevel.PUBLIC);
+            assertThat(responses)
+                .extracting(FeedResponse::isOwner)
+                .containsExactly(true, false);
+
+            verify(feedRepository).findAccessibleFeeds(accessLevels);
+        }
+
+        @Test
+        void getFeeds_PRIVATE_사용자는_PUBLIC_LIMITED_PRIVATE_피드를_반환한다() {
+            // given
+            List<ContentAccessLevel> accessLevels = List.of(
+                ContentAccessLevel.PUBLIC,
+                ContentAccessLevel.LIMITED,
+                ContentAccessLevel.PRIVATE
+            );
+            User viewer = createUser(10L, ContentAccessLevel.PRIVATE);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed publicFeed = createFeed(1L, "PUBLIC 피드", ContentAccessLevel.PUBLIC, author);
+            Feed limitedFeed = createFeed(2L, "LIMITED 피드", ContentAccessLevel.LIMITED, author);
+            Feed privateFeed = createFeed(3L, "PRIVATE 피드", ContentAccessLevel.PRIVATE, viewer);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findAccessibleFeeds(accessLevels))
+                .thenReturn(List.of(privateFeed, limitedFeed, publicFeed));
+
+            // when
+            List<FeedResponse> responses = feedService.getFeeds(principal);
+
+            // then
+            assertThat(responses).hasSize(3);
+            assertThat(responses)
+                .extracting(FeedResponse::requiredAccessLevel)
+                .containsExactly(
+                    ContentAccessLevel.PRIVATE,
+                    ContentAccessLevel.LIMITED,
+                    ContentAccessLevel.PUBLIC
+                );
+            assertThat(responses)
+                .extracting(FeedResponse::isOwner)
+                .containsExactly(true, false, false);
+
+            verify(feedRepository).findAccessibleFeeds(accessLevels);
+        }
+
+        @Test
+        void getFeeds_삭제된_피드는_반환하지않는다() {
+            // given
+            List<ContentAccessLevel> accessLevels = List.of(
+                ContentAccessLevel.PUBLIC,
+                ContentAccessLevel.LIMITED,
+                ContentAccessLevel.PRIVATE
+            );
+            User viewer = createUser(10L, ContentAccessLevel.PRIVATE);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed activeFeed = createFeed(1L, "노출 피드", ContentAccessLevel.PUBLIC, author);
+            Feed deletedFeed = createFeed(2L, "삭제된 피드", ContentAccessLevel.PRIVATE, author);
+            deletedFeed.setDeletedAt(LocalDateTime.now());
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findAccessibleFeeds(accessLevels))
+                .thenReturn(List.of(deletedFeed, activeFeed));
+
+            // when
+            List<FeedResponse> responses = feedService.getFeeds(principal);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses)
+                .extracting(FeedResponse::feedId)
+                .containsExactly(1L);
+            assertThat(responses)
+                .extracting(FeedResponse::content)
+                .doesNotContain("삭제된 피드");
+
+            verify(feedRepository).findAccessibleFeeds(accessLevels);
+        }
+    }
+
+    @Nested
+    class SaveFeedTest {
+
+        @Test
+        void saveFeed_유효한요청이면_피드를_저장하고_응답을_반환한다() {
+            // given
+            User author = createUser(10L, ContentAccessLevel.PRIVATE);
+            FeedCreateRequest request = new FeedCreateRequest(
+                "<script>alert('xss')</script>오늘의 기록",
+                ContentAccessLevel.LIMITED
+            );
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(author));
+            when(feedRepository.save(any(Feed.class))).thenAnswer(invocation -> {
+                Feed feed = invocation.getArgument(0);
+                feed.setId(100L);
+                return feed;
+            });
+
+            // when
+            FeedResponse response = feedService.saveFeed(principal, request);
+
+            // then
+            ArgumentCaptor<Feed> feedCaptor = ArgumentCaptor.forClass(Feed.class);
+            verify(feedRepository).save(feedCaptor.capture());
+
+            Feed savedFeed = feedCaptor.getValue();
+            assertThat(savedFeed.getContent()).isEqualTo("오늘의 기록");
+            assertThat(savedFeed.getRequiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
+            assertThat(savedFeed.getAuthor()).isEqualTo(author);
+            assertThat(savedFeed.getDeletedAt()).isNull();
+
+            assertThat(response.feedId()).isEqualTo(100L);
+            assertThat(response.authorNickname()).isEqualTo("닉네임10");
+            assertThat(response.content()).isEqualTo("오늘의 기록");
+            assertThat(response.requiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
+            assertThat(response.isOwner()).isTrue();
+        }
+
+        @Test
+        void saveFeed_공백과_줄바꿈을_유지한다() {
+            // given
+            User author = createUser(10L, ContentAccessLevel.PRIVATE);
+            String content = "  첫 줄\n\n  둘째  줄  ";
+            FeedCreateRequest request = new FeedCreateRequest(
+                content,
+                ContentAccessLevel.PUBLIC
+            );
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(author));
+            when(feedRepository.save(any(Feed.class))).thenAnswer(invocation -> {
+                Feed feed = invocation.getArgument(0);
+                feed.setId(100L);
+                return feed;
+            });
+
+            // when
+            FeedResponse response = feedService.saveFeed(principal, request);
+
+            // then
+            ArgumentCaptor<Feed> feedCaptor = ArgumentCaptor.forClass(Feed.class);
+            verify(feedRepository).save(feedCaptor.capture());
+
+            assertThat(feedCaptor.getValue().getContent()).isEqualTo(content);
+            assertThat(response.content()).isEqualTo(content);
+        }
+
+        @Test
+        void saveFeed_principal에_userId가_없으면_인증실패_예외를_발생시킨다() {
+            // given
+            FeedCreateRequest request = new FeedCreateRequest("피드 내용", ContentAccessLevel.PUBLIC);
+            when(principal.getAttributes()).thenReturn(Map.of("id", "kakao-only"));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.saveFeed(principal, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_USER_ID_INVALID));
+            verify(feedRepository, never()).save(any(Feed.class));
+        }
+
+        @Test
+        void saveFeed_사용자가_존재하지않으면_사용자없음_예외를_발생시킨다() {
+            // given
+            FeedCreateRequest request = new FeedCreateRequest("피드 내용", ContentAccessLevel.PUBLIC);
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedService.saveFeed(principal, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_USER_NOT_FOUND));
+            verify(feedRepository, never()).save(any(Feed.class));
+        }
+
+        @Test
+        void saveFeed_태그제거후내용이비면_내용유효성_예외를_발생시킨다() {
+            // given
+            User author = createUser(10L, ContentAccessLevel.PUBLIC);
+            FeedCreateRequest request = new FeedCreateRequest(
+                "<script>alert('xss')</script>",
+                ContentAccessLevel.PUBLIC
+            );
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(author));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.saveFeed(principal, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_CONTENT_INVALID));
+            verify(feedRepository, never()).save(any(Feed.class));
+        }
+
+        @Test
+        void saveFeed_requiredAccessLevel이_null이면_접근권한유효성_예외를_발생시킨다() {
+            // given
+            User author = createUser(10L, ContentAccessLevel.PUBLIC);
+            FeedCreateRequest request = new FeedCreateRequest("피드 내용", null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(author));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.saveFeed(principal, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_ACCESS_LEVEL_INVALID));
+            verify(feedRepository, never()).save(any(Feed.class));
+        }
+    }
+
+    @Nested
+    class UpdateFeedTest {
+
+        @Test
+        void updateFeed_피드소유자면_피드를_수정하고_응답을_반환한다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PRIVATE);
+            Feed feed = createFeed(100L, "기존 피드", ContentAccessLevel.PUBLIC, viewer);
+            FeedUpdateRequest request = new FeedUpdateRequest(
+                "<script>alert('xss')</script>수정된 피드",
+                ContentAccessLevel.LIMITED
+            );
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when
+            FeedResponse response = feedService.updateFeed(principal, 100L, request);
+
+            // then
+            assertThat(feed.getContent()).isEqualTo("수정된 피드");
+            assertThat(feed.getRequiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
+
+            assertThat(response.feedId()).isEqualTo(100L);
+            assertThat(response.content()).isEqualTo("수정된 피드");
+            assertThat(response.requiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
+            assertThat(response.isOwner()).isTrue();
+        }
+
+        @Test
+        void updateFeed_공백과_줄바꿈을_유지한다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PRIVATE);
+            Feed feed = createFeed(100L, "기존 피드", ContentAccessLevel.PUBLIC, viewer);
+            String content = "  수정된 피드\n\n  다음 줄  ";
+            FeedUpdateRequest request = new FeedUpdateRequest(content, null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when
+            FeedResponse response = feedService.updateFeed(principal, 100L, request);
+
+            // then
+            assertThat(feed.getContent()).isEqualTo(content);
+            assertThat(response.content()).isEqualTo(content);
+        }
+
+        @Test
+        void updateFeed_principal에_userId가_없으면_인증실패_예외를_발생시킨다() {
+            // given
+            FeedUpdateRequest request = new FeedUpdateRequest("수정된 피드", null);
+            when(principal.getAttributes()).thenReturn(Map.of("id", "kakao-only"));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.updateFeed(principal, 100L, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_USER_ID_INVALID));
+            verify(feedRepository, never()).findByIdAndDeletedAtIsNull(100L);
+        }
+
+        @Test
+        void updateFeed_피드가_존재하지않으면_피드없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            FeedUpdateRequest request = new FeedUpdateRequest("수정된 피드", null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedService.updateFeed(principal, 100L, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_NOT_FOUND));
+        }
+
+        @Test
+        void updateFeed_피드소유자가_아니면_권한없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "기존 피드", ContentAccessLevel.PUBLIC, author);
+            FeedUpdateRequest request = new FeedUpdateRequest("수정된 피드", null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.updateFeed(principal, 100L, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_FORBIDDEN));
+            assertThat(feed.getContent()).isEqualTo("기존 피드");
+        }
+
+        @Test
+        void updateFeed_수정할값이_없으면_수정요청유효성_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "기존 피드", ContentAccessLevel.PUBLIC, viewer);
+            FeedUpdateRequest request = new FeedUpdateRequest(null, null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.updateFeed(principal, 100L, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_UPDATE_REQUEST_INVALID));
+        }
+
+        @Test
+        void updateFeed_태그제거후내용이비면_내용유효성_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "기존 피드", ContentAccessLevel.PUBLIC, viewer);
+            FeedUpdateRequest request = new FeedUpdateRequest("<script>alert('xss')</script>", null);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.updateFeed(principal, 100L, request))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_CONTENT_INVALID));
+            assertThat(feed.getContent()).isEqualTo("기존 피드");
+        }
+    }
+
+    @Nested
+    class DeleteFeedTest {
+
+        @Test
+        void deleteFeed_피드소유자면_deletedAt을_설정한다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "삭제할 피드", ContentAccessLevel.PUBLIC, viewer);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when
+            feedService.deleteFeed(principal, 100L);
+
+            // then
+            assertThat(feed.getDeletedAt()).isNotNull();
+        }
+
+        @Test
+        void deleteFeed_principal에_userId가_없으면_인증실패_예외를_발생시킨다() {
+            // given
+            when(principal.getAttributes()).thenReturn(Map.of("id", "kakao-only"));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.deleteFeed(principal, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_USER_ID_INVALID));
+            verify(feedRepository, never()).findByIdAndDeletedAtIsNull(100L);
+        }
+
+        @Test
+        void deleteFeed_피드가_존재하지않으면_피드없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedService.deleteFeed(principal, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_NOT_FOUND));
+        }
+
+        @Test
+        void deleteFeed_피드소유자가_아니면_권한없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "삭제할 피드", ContentAccessLevel.PUBLIC, author);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.deleteFeed(principal, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_FORBIDDEN));
+            assertThat(feed.getDeletedAt()).isNull();
+        }
+    }
+
+    private User createUser(Long userId, ContentAccessLevel contentAccessLevel) {
+        User user = new User();
+        user.setId(userId);
+        user.setKakaoId("kakao-" + userId);
+        user.setName("사용자" + userId);
+        user.setNickname("닉네임" + userId);
+        user.setEmail("user" + userId + "@test.com");
+        user.setRole(Role.USER);
+        user.setContentAccessLevel(contentAccessLevel);
+        return user;
+    }
+
+    private Feed createFeed(
+        Long feedId,
+        String content,
+        ContentAccessLevel requiredAccessLevel,
+        User author
+    ) {
+        Feed feed = new Feed();
+        feed.setId(feedId);
+        feed.setContent(content);
+        feed.setRequiredAccessLevel(requiredAccessLevel);
+        feed.setAuthor(author);
+        return feed;
+    }
+}


### PR DESCRIPTION
## PR 요약
- 피드 조회/작성/수정/삭제 API를 추가했습니다.
- 사용자 콘텐츠 접근 레벨과 피드 접근 권한을 기준으로 조회 범위를 제한합니다.
- 피드 생성/수정 입력은 HTML 태그를 제거하되 공백과 줄바꿈은 보존하도록 처리했습니다.
- 피드 테이블과 사용자 `content_access_level` 컬럼을 추가하는 Liquibase changelog를 포함했습니다.
