### PR TITLE
refactor: 피드 글자 제한 2000자로 변경 (#129)

### DIFF
--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedCreateRequest.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedCreateRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
 public record FeedCreateRequest(
     @Schema(description = "피드 내용", example = "오늘의 짧은 기록")
     @NotBlank(message = "피드 내용은 비어 있을 수 없습니다.")
-    @Size(max = 500, message = "피드는 500자 이하로 입력해주세요.")
+    @Size(max = 2000, message = "피드는 2000자 이하로 입력해주세요.")
     String content,
 
     @Schema(description = "피드 접근 권한", example = "PUBLIC")

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedUpdateRequest.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/request/FeedUpdateRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 @Schema(description = "피드 수정 요청")
 public record FeedUpdateRequest(
     @Schema(description = "수정할 피드 내용", example = "수정된 짧은 기록")
-    @Size(max = 500, message = "피드는 500자 이하로 입력해주세요.")
+    @Size(max = 2000, message = "피드는 2000자 이하로 입력해주세요.")
     String content,
 
     @Schema(description = "수정할 피드 접근 권한", example = "LIMITED")

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/Feed.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/Feed.java
@@ -30,8 +30,8 @@ public class Feed extends BaseTimeEntity {
     private Long id;
 
     @NotBlank
-    @Size(max = 500)
-    @Column(length = 500, nullable = false)
+    @Size(max = 2000)
+    @Column(length = 2000, nullable = false)
     private String content;
 
     @NotNull

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -31,3 +31,5 @@ databaseChangeLog:
       file: db/changelog/v1_0/015-create-comment-table.yaml
   - include:
       file: db/changelog/v1_0/016-create-feed-table-and-content-access-level.yaml
+  - include:
+      file: db/changelog/v1_0/017-increase-feed-content-length.yaml

--- a/src/main/resources/db/changelog/v1_0/017-increase-feed-content-length.yaml
+++ b/src/main/resources/db/changelog/v1_0/017-increase-feed-content-length.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 037-increase-feed-content-length
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed }
+          - columnExists:
+              tableName: feed
+              columnName: content
+      changes:
+        - modifyDataType:
+            tableName: feed
+            columnName: content
+            newDataType: VARCHAR(2000)


### PR DESCRIPTION
## 변경 사항
- 피드 생성/수정 요청의 글자 제한을 2000자로 변경했습니다.
- `Feed.content` 엔티티 컬럼 길이를 2000자로 확장했습니다.
- Liquibase changelog를 추가해 `feed.content`를 `VARCHAR(2000)`으로 변경하도록 반영했습니다.

## 변경 이유
- 기존 500자 제한으로 긴 피드 작성 시 불편함이 있어 제한 범위를 확장합니다.

## 영향
- 피드 생성/수정 시 최대 2000자까지 입력할 수 있습니다.
- 기존 데이터는 유지되고 컬럼 길이만 확장됩니다.

## 검증
- `./gradlew test`

Closes #129
