### PR TITLE
feat: 일반 사용자 피드 및 이미지 쓰기 권한 허용

### DIFF
--- a/src/main/java/com/yeo_li/yeol_post/domain/image/ImageController.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/image/ImageController.java
@@ -16,6 +16,7 @@ import org.springframework.http.CacheControl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -60,10 +61,11 @@ public class ImageController {
             content = @Content(mediaType = "multipart/form-data",
                 schema = @Schema(type = "string", format = "binary"))
         )
-        @RequestParam("file") MultipartFile file
+        @RequestParam("file") MultipartFile file,
+        Authentication authentication
     ) {
 
-        ImageService.StoredImage storedImage = imageService.store(file);
+        ImageService.StoredImage storedImage = imageService.store(file, isAdmin(authentication));
         ImageUploadResponse response = new ImageUploadResponse(storedImage.url());
         return ResponseEntity
             .status(HttpStatus.OK)
@@ -90,5 +92,10 @@ public class ImageController {
             .contentType(mediaType)
             .cacheControl(CacheControl.maxAge(365, TimeUnit.DAYS).cachePublic())
             .body(resource);
+    }
+
+    private boolean isAdmin(Authentication authentication) {
+        return authentication != null && authentication.getAuthorities().stream()
+            .anyMatch(authority -> "ROLE_ADMIN".equals(authority.getAuthority()));
     }
 }

--- a/src/main/java/com/yeo_li/yeol_post/domain/image/ImageService.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/image/ImageService.java
@@ -55,7 +55,11 @@ public class ImageService {
     }
 
     public StoredImage store(MultipartFile file) {
-        byte[] bytes = readAndValidateFileBytes(file);
+        return store(file, false);
+    }
+
+    public StoredImage store(MultipartFile file, boolean allowOversizedImage) {
+        byte[] bytes = readAndValidateFileBytes(file, allowOversizedImage);
         ImageFormat imageFormat = validateImage(file, bytes);
         BufferedImage image = decodeImage(bytes);
 
@@ -102,12 +106,12 @@ public class ImageService {
         return resolveFormatFromFilename(filename).mediaType;
     }
 
-    private byte[] readAndValidateFileBytes(MultipartFile file) {
+    private byte[] readAndValidateFileBytes(MultipartFile file, boolean allowOversizedImage) {
         if (file == null || file.isEmpty()) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
 
-        if (file.getSize() > maxFileSizeBytes) {
+        if (!allowOversizedImage && file.getSize() > maxFileSizeBytes) {
             throw new GeneralException(ErrorStatus.PAYLOAD_TOO_LARGE);
         }
 
@@ -116,7 +120,7 @@ public class ImageService {
             if (bytes.length == 0) {
                 throw new GeneralException(ErrorStatus.BAD_REQUEST);
             }
-            if (bytes.length > maxFileSizeBytes) {
+            if (!allowOversizedImage && bytes.length > maxFileSizeBytes) {
                 throw new GeneralException(ErrorStatus.PAYLOAD_TOO_LARGE);
             }
             return bytes;

--- a/src/main/java/com/yeo_li/yeol_post/domain/image/ImageService.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/image/ImageService.java
@@ -2,28 +2,51 @@ package com.yeo_li.yeol_post.domain.image;
 
 import com.yeo_li.yeol_post.global.common.response.code.resultCode.ErrorStatus;
 import com.yeo_li.yeol_post.global.common.response.exception.GeneralException;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
+import javax.imageio.ImageIO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @Service
 public class ImageService {
 
-    private final Path uploadDir;
+    private static final byte[] PNG_SIGNATURE =
+        new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+    private static final String SVG_MEDIA_TYPE = "image/svg+xml";
+    private static final Map<String, ImageFormat> IMAGE_FORMAT_BY_MEDIA_TYPE = Map.of(
+        MediaType.IMAGE_JPEG_VALUE, ImageFormat.JPEG,
+        "image/jpg", ImageFormat.JPEG,
+        MediaType.IMAGE_PNG_VALUE, ImageFormat.PNG
+    );
 
-    public ImageService(@Value("${app.image.upload-dir:uploads/images}") String uploadDir) {
+    private final Path uploadDir;
+    private final long maxFileSizeBytes;
+
+    public ImageService(
+        @Value("${app.image.upload-dir:uploads/images}") String uploadDir,
+        @Value("${app.image.max-file-size:5MB}") DataSize maxFileSize
+    ) {
         this.uploadDir = Paths.get(uploadDir).toAbsolutePath().normalize();
+        this.maxFileSizeBytes = maxFileSize.toBytes();
         try {
             Files.createDirectories(this.uploadDir);
         } catch (IOException e) {
@@ -32,18 +55,18 @@ public class ImageService {
     }
 
     public StoredImage store(MultipartFile file) {
-        validateImage(file);
+        byte[] bytes = readAndValidateFileBytes(file);
+        ImageFormat imageFormat = validateImage(file, bytes);
+        BufferedImage image = decodeImage(bytes);
 
-        String originalFilename = file.getOriginalFilename();
-        String extension = extractExtension(originalFilename);
-        String filename = generateUniqueFilename(extension);
+        String filename = generateUniqueFilename(imageFormat.extension);
         Path targetPath = uploadDir.resolve(filename).normalize();
         if (!targetPath.startsWith(uploadDir)) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
 
         try {
-            Files.copy(file.getInputStream(), targetPath, StandardCopyOption.REPLACE_EXISTING);
+            reencodeImage(image, imageFormat, targetPath);
         } catch (IOException e) {
             throw new GeneralException(ErrorStatus.INTERNAL_SERVER_ERROR);
         }
@@ -57,6 +80,8 @@ public class ImageService {
     }
 
     public Resource loadAsResource(String filename) {
+        validateServableImageFilename(filename);
+
         Path filePath = uploadDir.resolve(filename).normalize();
         if (!filePath.startsWith(uploadDir)) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
@@ -74,26 +99,131 @@ public class ImageService {
     }
 
     public MediaType resolveContentType(String filename) {
-        Path filePath = uploadDir.resolve(filename).normalize();
-        try {
-            String contentType = Files.probeContentType(filePath);
-            if (contentType != null) {
-                return MediaType.parseMediaType(contentType);
-            }
-        } catch (IOException ignored) {
-            // fall through to default
-        }
-        return MediaType.APPLICATION_OCTET_STREAM;
+        return resolveFormatFromFilename(filename).mediaType;
     }
 
-    private void validateImage(MultipartFile file) {
+    private byte[] readAndValidateFileBytes(MultipartFile file) {
         if (file == null || file.isEmpty()) {
             throw new GeneralException(ErrorStatus.BAD_REQUEST);
         }
-        String contentType = file.getContentType();
-        if (contentType == null || !contentType.toLowerCase(Locale.ROOT).startsWith("image/")) {
+
+        if (file.getSize() > maxFileSizeBytes) {
+            throw new GeneralException(ErrorStatus.PAYLOAD_TOO_LARGE);
+        }
+
+        try {
+            byte[] bytes = file.getBytes();
+            if (bytes.length == 0) {
+                throw new GeneralException(ErrorStatus.BAD_REQUEST);
+            }
+            if (bytes.length > maxFileSizeBytes) {
+                throw new GeneralException(ErrorStatus.PAYLOAD_TOO_LARGE);
+            }
+            return bytes;
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.BAD_REQUEST);
+        }
+    }
+
+    private ImageFormat validateImage(MultipartFile file, byte[] bytes) {
+        String declaredContentType = normalizeContentType(file.getContentType());
+        String extension = extractExtension(file.getOriginalFilename());
+
+        if (isSvg(declaredContentType, extension, bytes)) {
             throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
         }
+
+        ImageFormat declaredFormat = IMAGE_FORMAT_BY_MEDIA_TYPE.get(declaredContentType);
+        if (declaredFormat == null) {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        if (!extension.isBlank() && !declaredFormat.matchesExtension(extension)) {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        ImageFormat magicFormat = detectMagicBytes(bytes);
+        if (magicFormat == null || magicFormat != declaredFormat) {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+
+        return magicFormat;
+    }
+
+    private BufferedImage decodeImage(byte[] bytes) {
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+            if (image == null || image.getWidth() <= 0 || image.getHeight() <= 0) {
+                throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
+            }
+            return image;
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.UNSUPPORTED_MEDIA_TYPE);
+        }
+    }
+
+    private void reencodeImage(BufferedImage image, ImageFormat imageFormat, Path targetPath)
+        throws IOException {
+        BufferedImage outputImage = imageFormat == ImageFormat.JPEG
+            ? convertToRgb(image)
+            : image;
+
+        try (OutputStream outputStream = Files.newOutputStream(targetPath)) {
+            boolean written = ImageIO.write(outputImage, imageFormat.writerFormat, outputStream);
+            if (!written) {
+                throw new IOException("No ImageIO writer found for " + imageFormat.writerFormat);
+            }
+        }
+    }
+
+    private BufferedImage convertToRgb(BufferedImage image) {
+        BufferedImage rgbImage =
+            new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = rgbImage.createGraphics();
+        try {
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            graphics.drawImage(image, 0, 0, null);
+        } finally {
+            graphics.dispose();
+        }
+        return rgbImage;
+    }
+
+    private String normalizeContentType(String contentType) {
+        if (contentType == null) {
+            return "";
+        }
+        int separatorIndex = contentType.indexOf(';');
+        String normalized = separatorIndex < 0 ? contentType : contentType.substring(0, separatorIndex);
+        return normalized.trim().toLowerCase(Locale.ROOT);
+    }
+
+    private boolean isSvg(String declaredContentType, String extension, byte[] bytes) {
+        if (SVG_MEDIA_TYPE.equals(declaredContentType) || "svg".equals(extension)) {
+            return true;
+        }
+
+        String prefix = new String(bytes, 0, Math.min(bytes.length, 512), StandardCharsets.UTF_8)
+            .trim()
+            .toLowerCase(Locale.ROOT);
+        return prefix.startsWith("<svg") || (prefix.startsWith("<?xml") && prefix.contains("<svg"));
+    }
+
+    private ImageFormat detectMagicBytes(byte[] bytes) {
+        if (bytes.length >= 3
+            && (bytes[0] & 0xFF) == 0xFF
+            && (bytes[1] & 0xFF) == 0xD8
+            && (bytes[2] & 0xFF) == 0xFF) {
+            return ImageFormat.JPEG;
+        }
+
+        if (bytes.length >= PNG_SIGNATURE.length
+            && Arrays.equals(Arrays.copyOf(bytes, PNG_SIGNATURE.length), PNG_SIGNATURE)) {
+            return ImageFormat.PNG;
+        }
+
+        return null;
     }
 
     private String extractExtension(String filename) {
@@ -106,6 +236,20 @@ public class ImageService {
         }
         String ext = filename.substring(dotIndex + 1).toLowerCase(Locale.ROOT);
         return ext.replaceAll("[^a-z0-9]", "");
+    }
+
+    private void validateServableImageFilename(String filename) {
+        resolveFormatFromFilename(filename);
+    }
+
+    private ImageFormat resolveFormatFromFilename(String filename) {
+        String extension = extractExtension(filename);
+        for (ImageFormat imageFormat : ImageFormat.values()) {
+            if (imageFormat.matchesExtension(extension)) {
+                return imageFormat;
+            }
+        }
+        throw new GeneralException(ErrorStatus.RESOURCE_NOT_FOUND);
     }
 
     private String generateUniqueFilename(String extension) {
@@ -124,5 +268,32 @@ public class ImageService {
 
     public record StoredImage(String filename, String url) {
 
+    }
+
+    private enum ImageFormat {
+        JPEG("jpg", "jpeg", MediaType.IMAGE_JPEG, "jpg", "jpeg"),
+        PNG("png", "png", MediaType.IMAGE_PNG, "png");
+
+        private final String extension;
+        private final String writerFormat;
+        private final MediaType mediaType;
+        private final String[] acceptedExtensions;
+
+        ImageFormat(String extension, String writerFormat, MediaType mediaType,
+            String... acceptedExtensions) {
+            this.extension = extension;
+            this.writerFormat = writerFormat;
+            this.mediaType = mediaType;
+            this.acceptedExtensions = acceptedExtensions;
+        }
+
+        private boolean matchesExtension(String extension) {
+            for (String acceptedExtension : acceptedExtensions) {
+                if (acceptedExtension.equals(extension)) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/src/main/java/com/yeo_li/yeol_post/global/common/response/code/resultCode/ErrorStatus.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/common/response/code/resultCode/ErrorStatus.java
@@ -17,6 +17,7 @@ public enum ErrorStatus implements BaseCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "GLOBAL404", "리소스를 찾을 수 없음"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL405", "허용되지 않는 메서드"),
     CONFLICT(HttpStatus.CONFLICT, "GLOBAL409", "리소스 충돌"),
+    PAYLOAD_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "GLOBAL413", "요청 본문이 너무 큽니다"),
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "GLOBAL415", "지원하지 않는 미디어 타입"),
 
     // 검증 에러

--- a/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
@@ -122,25 +122,27 @@ public class SecurityConfig {
                     "/api/v1/posts/*/views"
                 ).permitAll()
 
+                // authenticated feed write endpoint
+                .requestMatchers(HttpMethod.POST, "/api/v1/feeds").authenticated()
+                .requestMatchers(HttpMethod.PATCH, "/api/v1/feeds/**").authenticated()
+                .requestMatchers(HttpMethod.DELETE, "/api/v1/feeds/**").authenticated()
+
                 // admin endpoint
                 .requestMatchers("/api/v1/drafts/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST,
                     "/api/v1/posts",
                     "/api/v1/categories",
-                    "/api/v1/images",
-                    "/api/v1/feeds"
+                    "/api/v1/images"
                 ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PATCH,
                     "/api/v1/posts/**",
                     "/api/v1/categories/**",
-                    "/api/v1/drafts/**",
-                    "/api/v1/feeds/**"
+                    "/api/v1/drafts/**"
                 ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/users/**").authenticated()
                 .requestMatchers(HttpMethod.DELETE,
                     "/api/v1/posts/**",
-                    "/api/v1/categories/**",
-                    "/api/v1/feeds/**"
+                    "/api/v1/categories/**"
                 ).hasRole("ADMIN")
                 .requestMatchers("/api/v1/**").authenticated()
                 .anyRequest().authenticated()

--- a/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
@@ -126,13 +126,13 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.POST, "/api/v1/feeds").authenticated()
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/feeds/**").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/feeds/**").authenticated()
+                .requestMatchers(HttpMethod.POST, "/api/v1/images").authenticated()
 
                 // admin endpoint
                 .requestMatchers("/api/v1/drafts/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.POST,
                     "/api/v1/posts",
-                    "/api/v1/categories",
-                    "/api/v1/images"
+                    "/api/v1/categories"
                 ).hasRole("ADMIN")
                 .requestMatchers(HttpMethod.PATCH,
                     "/api/v1/posts/**",

--- a/src/test/java/com/yeo_li/yeol_post/domain/image/ImageServiceTest.java
+++ b/src/test/java/com/yeo_li/yeol_post/domain/image/ImageServiceTest.java
@@ -123,6 +123,33 @@ class ImageServiceTest {
             );
     }
 
+    @Test
+    void store_관리자면_허용_용량을_초과해도_저장한다() throws IOException {
+        setupRequestContext();
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofBytes(10));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "sample.png",
+            "image/png",
+            pngBytes()
+        );
+
+        ImageService.StoredImage storedImage = imageService.store(file, true);
+
+        Path savedFile = uploadDir.resolve(storedImage.filename());
+        assertThat(Files.exists(savedFile)).isTrue();
+        assertThat(Files.readAllBytes(savedFile))
+            .startsWith(PNG_SIGNATURE);
+    }
+
+    private void setupRequestContext() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    }
+
     private byte[] pngBytes() throws IOException {
         BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
         image.setRGB(0, 0, Color.RED.getRGB());

--- a/src/test/java/com/yeo_li/yeol_post/domain/image/ImageServiceTest.java
+++ b/src/test/java/com/yeo_li/yeol_post/domain/image/ImageServiceTest.java
@@ -1,0 +1,137 @@
+package com.yeo_li.yeol_post.domain.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.yeo_li.yeol_post.global.common.response.code.resultCode.ErrorStatus;
+import com.yeo_li.yeol_post.global.common.response.exception.GeneralException;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class ImageServiceTest {
+
+    private static final byte[] PNG_SIGNATURE =
+        new byte[]{(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
+
+    @TempDir
+    Path uploadDir;
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
+    }
+
+    @Test
+    void store_PNG_이미지를_검증하고_재인코딩해_저장한다() throws IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContextPath("");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofMegabytes(1));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "sample.png",
+            "image/png",
+            pngBytes()
+        );
+
+        ImageService.StoredImage storedImage = imageService.store(file);
+
+        Path savedFile = uploadDir.resolve(storedImage.filename());
+        assertThat(storedImage.filename()).endsWith(".png");
+        assertThat(Files.exists(savedFile)).isTrue();
+        assertThat(Files.readAllBytes(savedFile))
+            .startsWith(PNG_SIGNATURE);
+    }
+
+    @Test
+    void store_SVG_이미지는_차단한다() {
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofMegabytes(1));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "malicious.svg",
+            "image/svg+xml",
+            "<svg><script>alert(1)</script></svg>".getBytes()
+        );
+
+        assertThatThrownBy(() -> imageService.store(file))
+            .isInstanceOfSatisfying(GeneralException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.UNSUPPORTED_MEDIA_TYPE)
+            );
+    }
+
+    @Test
+    void store_이미지_MIME으로_위장한_비이미지는_차단한다() {
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofMegabytes(1));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "fake.png",
+            "image/png",
+            "not an image".getBytes()
+        );
+
+        assertThatThrownBy(() -> imageService.store(file))
+            .isInstanceOfSatisfying(GeneralException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.UNSUPPORTED_MEDIA_TYPE)
+            );
+    }
+
+    @Test
+    void store_MIME과_확장자가_일치하지_않으면_차단한다() throws IOException {
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofMegabytes(1));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "sample.jpg",
+            "image/png",
+            pngBytes()
+        );
+
+        assertThatThrownBy(() -> imageService.store(file))
+            .isInstanceOfSatisfying(GeneralException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.UNSUPPORTED_MEDIA_TYPE)
+            );
+    }
+
+    @Test
+    void store_허용_용량을_초과하면_차단한다() throws IOException {
+        ImageService imageService = new ImageService(uploadDir.toString(), DataSize.ofBytes(10));
+        MockMultipartFile file = new MockMultipartFile(
+            "file",
+            "sample.png",
+            "image/png",
+            pngBytes()
+        );
+
+        assertThatThrownBy(() -> imageService.store(file))
+            .isInstanceOfSatisfying(GeneralException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(ErrorStatus.PAYLOAD_TOO_LARGE)
+            );
+    }
+
+    private byte[] pngBytes() throws IOException {
+        BufferedImage image = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
+        image.setRGB(0, 0, Color.RED.getRGB());
+        image.setRGB(1, 0, Color.GREEN.getRGB());
+        image.setRGB(0, 1, Color.BLUE.getRGB());
+        image.setRGB(1, 1, Color.WHITE.getRGB());
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(image, "png", outputStream);
+        return outputStream.toByteArray();
+    }
+}


### PR DESCRIPTION
## 작업 내용
- POST /api/v1/feeds를 로그인 사용자에게 허용하도록 변경했습니다.
- PATCH /api/v1/feeds/**, DELETE /api/v1/feeds/**를 로그인 사용자에게 허용하도록 변경했습니다.
- POST /api/v1/images를 로그인 사용자에게 허용하도록 변경했습니다.
- 이미지 업로드 검증을 강화했습니다.
  - 일반 사용자 업로드 용량을 기본 5MB로 제한
  - 관리자는 이미지 업로드 용량 제한 예외 허용
  - JPEG/PNG만 허용
  - SVG 및 비허용 확장자 차단
  - magic bytes 검증
  - ImageIO decode 검증
  - 원본 파일 복사 대신 JPEG/PNG 재인코딩 저장
- 알 수 없는 확장자의 업로드 파일 제공을 차단했습니다.

## 영향
- USER와 ADMIN 모두 피드 작성/수정/삭제 API에 접근할 수 있습니다.
- USER와 ADMIN 모두 이미지 업로드 API에 접근할 수 있습니다.
- ADMIN은 업로드 용량 제한을 우회할 수 있습니다.
- 비로그인 사용자는 피드 쓰기 및 이미지 업로드에 접근할 수 없습니다.
- 수정/삭제 시 본인 글 검증은 기존 FeedService.validateOwner() 로직이 유지합니다.
- GIF/WebP/SVG 업로드는 차단됩니다. 필요하면 별도 라이브러리와 정책으로 확장해야 합니다.

## 검증
- ./gradlew test
- git diff --check

## 관련 이슈
- Close #132
