### PR TITLE
feat: 피드 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/controller/FeedController.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/controller/FeedController.java
@@ -62,4 +62,22 @@ public class FeedController {
         feedService.deleteFeed(principal, feedId);
         return ResponseEntity.ok(ApiResponse.onSuccess());
     }
+
+    @PostMapping("/{feedId}/likes")
+    public ResponseEntity<ApiResponse<Void>> likeFeed(
+        @AuthenticationPrincipal OAuth2User principal,
+        @PathVariable Long feedId
+    ) {
+        feedService.likeFeed(principal, feedId);
+        return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
+
+    @DeleteMapping("/{feedId}/likes")
+    public ResponseEntity<ApiResponse<Void>> unlikeFeed(
+        @AuthenticationPrincipal OAuth2User principal,
+        @PathVariable Long feedId
+    ) {
+        feedService.unlikeFeed(principal, feedId);
+        return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
 }

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/response/FeedResponse.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/dto/response/FeedResponse.java
@@ -9,7 +9,9 @@ public record FeedResponse(
     String content,
     ContentAccessLevel requiredAccessLevel,
     LocalDateTime createdAt,
-    boolean isOwner
+    boolean isOwner,
+    long likeCount,
+    boolean isLiked
 ) {
 
 }

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/FeedLike.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/entity/FeedLike.java
@@ -1,0 +1,47 @@
+package com.yeo_li.yeol_post.domain.feed.entity;
+
+import com.yeo_li.yeol_post.domain.user.domain.User;
+import com.yeo_li.yeol_post.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(
+    name = "feed_like",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "feed_id"})
+    }
+)
+@Getter
+@Setter
+public class FeedLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id", nullable = false)
+    private Feed feed;
+
+    public FeedLike(User user, Feed feed) {
+        this.user = user;
+        this.feed = feed;
+    }
+
+    public FeedLike() {
+    }
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedLikeCount.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedLikeCount.java
@@ -1,0 +1,8 @@
+package com.yeo_li.yeol_post.domain.feed.repository;
+
+public record FeedLikeCount(
+    Long feedId,
+    Long likeCount
+) {
+
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/repository/FeedLikeRepository.java
@@ -1,0 +1,48 @@
+package com.yeo_li.yeol_post.domain.feed.repository;
+
+import com.yeo_li.yeol_post.domain.feed.entity.FeedLike;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
+
+    @Modifying
+    @Query(value = """
+        INSERT IGNORE INTO feed_like (user_id, feed_id, created_at, updated_at)
+        VALUES (:userId, :feedId, NOW(6), NOW(6))
+        """, nativeQuery = true)
+    int insertIgnore(
+        @Param("userId") Long userId,
+        @Param("feedId") Long feedId
+    );
+
+    void deleteByFeedIdAndUserId(Long feedId, Long userId);
+
+    @Query("""
+        SELECT new com.yeo_li.yeol_post.domain.feed.repository.FeedLikeCount(
+            fl.feed.id,
+            COUNT(fl.id)
+        )
+        FROM FeedLike fl
+        WHERE fl.feed.id IN :feedIds
+        GROUP BY fl.feed.id
+        """)
+    List<FeedLikeCount> countByFeedIds(@Param("feedIds") Collection<Long> feedIds);
+
+    @Query("""
+        SELECT fl.feed.id
+        FROM FeedLike fl
+        WHERE fl.user.id = :userId
+          AND fl.feed.id IN :feedIds
+        """)
+    List<Long> findLikedFeedIds(
+        @Param("userId") Long userId,
+        @Param("feedIds") Collection<Long> feedIds
+    );
+}

--- a/src/main/java/com/yeo_li/yeol_post/domain/feed/service/FeedService.java
+++ b/src/main/java/com/yeo_li/yeol_post/domain/feed/service/FeedService.java
@@ -5,6 +5,8 @@ import com.yeo_li.yeol_post.domain.feed.dto.request.FeedUpdateRequest;
 import com.yeo_li.yeol_post.domain.feed.dto.response.FeedResponse;
 import com.yeo_li.yeol_post.domain.feed.entity.Feed;
 import com.yeo_li.yeol_post.domain.feed.exception.FeedExceptionType;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedLikeCount;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedLikeRepository;
 import com.yeo_li.yeol_post.domain.feed.repository.FeedRepository;
 import com.yeo_li.yeol_post.domain.user.domain.User;
 import com.yeo_li.yeol_post.domain.user.repository.UserRepository;
@@ -12,8 +14,14 @@ import com.yeo_li.yeol_post.global.common.entity.ContentAccessLevel;
 import com.yeo_li.yeol_post.global.common.response.exception.GeneralException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -28,6 +36,7 @@ public class FeedService {
 
     private final UserRepository userRepository;
     private final FeedRepository feedRepository;
+    private final FeedLikeRepository feedLikeRepository;
 
     public List<FeedResponse> getFeeds(OAuth2User principal) {
         Long userId = getUserId(principal);
@@ -73,34 +82,46 @@ public class FeedService {
     }
 
     private List<FeedResponse> convertFeedResponseList(List<Feed> feeds, User viewer) {
+        List<Feed> activeFeeds = filterActiveFeeds(feeds);
+        FeedLikeContext likeContext = getFeedLikeContext(activeFeeds, viewer.getId());
         List<FeedResponse> feedResponses = new ArrayList<>();
-        for (Feed feed : feeds) {
-            if (feed.getDeletedAt() == null) {
-                feedResponses.add(convertFeedResponse(feed, viewer));
-            }
+        for (Feed feed : activeFeeds) {
+            feedResponses.add(convertFeedResponse(feed, viewer, likeContext));
         }
         return feedResponses;
     }
 
-    private FeedResponse convertFeedResponse(Feed feed, User user) {
+    private List<Feed> filterActiveFeeds(List<Feed> feeds) {
+        List<Feed> activeFeeds = new ArrayList<>();
+        for (Feed feed : feeds) {
+            if (feed.getDeletedAt() == null) {
+                activeFeeds.add(feed);
+            }
+        }
+        return activeFeeds;
+    }
+
+    private FeedResponse convertFeedResponse(Feed feed, User user, FeedLikeContext likeContext) {
         return new FeedResponse(feed.getId(), feed.getAuthor().getNickname(), feed.getContent(),
             feed.getRequiredAccessLevel(),
-            feed.getCreatedAt(), Objects.equals(feed.getAuthor().getId(), user.getId()));
+            feed.getCreatedAt(), Objects.equals(feed.getAuthor().getId(), user.getId()),
+            likeContext.countOf(feed.getId()), likeContext.isLiked(feed.getId()));
     }
 
     private List<FeedResponse> convertFeedResponseListNoViewer(List<Feed> feeds) {
+        List<Feed> activeFeeds = filterActiveFeeds(feeds);
+        FeedLikeContext likeContext = getFeedLikeContext(activeFeeds, null);
         List<FeedResponse> feedResponses = new ArrayList<>();
-        for (Feed feed : feeds) {
-            if (feed.getDeletedAt() == null) {
-                feedResponses.add(convertFeedResponseNoViewer(feed));
-            }
+        for (Feed feed : activeFeeds) {
+            feedResponses.add(convertFeedResponseNoViewer(feed, likeContext));
         }
         return feedResponses;
     }
 
-    private FeedResponse convertFeedResponseNoViewer(Feed feed) {
+    private FeedResponse convertFeedResponseNoViewer(Feed feed, FeedLikeContext likeContext) {
         return new FeedResponse(feed.getId(), feed.getAuthor().getNickname(), feed.getContent(),
-            feed.getRequiredAccessLevel(), feed.getCreatedAt(), false);
+            feed.getRequiredAccessLevel(), feed.getCreatedAt(), false,
+            likeContext.countOf(feed.getId()), false);
     }
 
     @Transactional
@@ -117,7 +138,7 @@ public class FeedService {
         feed.setAuthor(author);
 
         Feed savedFeed = feedRepository.save(feed);
-        return convertFeedResponse(savedFeed, author);
+        return convertFeedResponse(savedFeed, author, FeedLikeContext.empty());
     }
 
     @Transactional
@@ -138,7 +159,7 @@ public class FeedService {
             feed.setRequiredAccessLevel(request.requiredAccessLevel());
         }
 
-        return convertFeedResponse(feed, author);
+        return convertFeedResponse(feed, author, getFeedLikeContext(List.of(feed), author.getId()));
     }
 
     @Transactional
@@ -148,6 +169,24 @@ public class FeedService {
         validateOwner(feed, author);
 
         feed.setDeletedAt(LocalDateTime.now());
+    }
+
+    @Transactional
+    public void likeFeed(OAuth2User principal, Long feedId) {
+        User viewer = getAuthenticatedUser(principal);
+        Feed feed = getActiveFeed(feedId);
+        validateAccessible(feed, viewer);
+
+        feedLikeRepository.insertIgnore(viewer.getId(), feed.getId());
+    }
+
+    @Transactional
+    public void unlikeFeed(OAuth2User principal, Long feedId) {
+        User viewer = getAuthenticatedUser(principal);
+        Feed feed = getActiveFeed(feedId);
+        validateAccessible(feed, viewer);
+
+        feedLikeRepository.deleteByFeedIdAndUserId(feed.getId(), viewer.getId());
     }
 
     private User getAuthenticatedUser(OAuth2User principal) {
@@ -168,6 +207,55 @@ public class FeedService {
     private void validateOwner(Feed feed, User viewer) {
         if (!Objects.equals(feed.getAuthor().getId(), viewer.getId())) {
             throw new GeneralException(FeedExceptionType.FEED_FORBIDDEN);
+        }
+    }
+
+    private void validateAccessible(Feed feed, User viewer) {
+        if (!viewer.getContentAccessLevel().accessibleLevels()
+            .contains(feed.getRequiredAccessLevel())) {
+            throw new GeneralException(FeedExceptionType.FEED_FORBIDDEN);
+        }
+    }
+
+    private FeedLikeContext getFeedLikeContext(List<Feed> feeds, Long viewerId) {
+        if (feeds.isEmpty()) {
+            return FeedLikeContext.empty();
+        }
+
+        List<Long> feedIds = feeds.stream()
+            .map(Feed::getId)
+            .toList();
+
+        Map<Long, FeedLikeCount> countByFeedId = feedLikeRepository.countByFeedIds(feedIds)
+            .stream()
+            .collect(Collectors.toMap(FeedLikeCount::feedId, Function.identity()));
+
+        Set<Long> likedFeedIds = viewerId == null
+            ? Collections.emptySet()
+            : new HashSet<>(feedLikeRepository.findLikedFeedIds(viewerId, feedIds));
+
+        return new FeedLikeContext(countByFeedId, likedFeedIds);
+    }
+
+    private record FeedLikeContext(
+        Map<Long, FeedLikeCount> countByFeedId,
+        Set<Long> likedFeedIds
+    ) {
+
+        private static FeedLikeContext empty() {
+            return new FeedLikeContext(Collections.emptyMap(), Collections.emptySet());
+        }
+
+        private long countOf(Long feedId) {
+            FeedLikeCount count = countByFeedId.get(feedId);
+            if (count == null) {
+                return 0L;
+            }
+            return count.likeCount();
+        }
+
+        private boolean isLiked(Long feedId) {
+            return likedFeedIds.contains(feedId);
         }
     }
 

--- a/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
+++ b/src/main/java/com/yeo_li/yeol_post/global/config/SecurityConfig.java
@@ -124,6 +124,7 @@ public class SecurityConfig {
 
                 // authenticated feed write endpoint
                 .requestMatchers(HttpMethod.POST, "/api/v1/feeds").authenticated()
+                .requestMatchers(HttpMethod.POST, "/api/v1/feeds/*/likes").authenticated()
                 .requestMatchers(HttpMethod.PATCH, "/api/v1/feeds/**").authenticated()
                 .requestMatchers(HttpMethod.DELETE, "/api/v1/feeds/**").authenticated()
                 .requestMatchers(HttpMethod.POST, "/api/v1/images").authenticated()

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -33,3 +33,5 @@ databaseChangeLog:
       file: db/changelog/v1_0/016-create-feed-table-and-content-access-level.yaml
   - include:
       file: db/changelog/v1_0/017-increase-feed-content-length.yaml
+  - include:
+      file: db/changelog/v1_0/018-create-feed-like-table.yaml

--- a/src/main/resources/db/changelog/v1_0/018-create-feed-like-table.yaml
+++ b/src/main/resources/db/changelog/v1_0/018-create-feed-like-table.yaml
@@ -1,0 +1,129 @@
+databaseChangeLog:
+  - changeSet:
+      id: 038-create-feed-like-table
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        not:
+          - tableExists:
+              tableName: feed_like
+      changes:
+        - createTable:
+            tableName: feed_like
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column: { name: created_at, type: DATETIME(6) }
+              - column: { name: updated_at, type: DATETIME(6) }
+              - column:
+                  name: user_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: feed_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+
+  - changeSet:
+      id: 039-add-uk-feed-like-user-feed
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed_like }
+          - columnExists:
+              tableName: feed_like
+              columnName: user_id
+          - columnExists:
+              tableName: feed_like
+              columnName: feed_id
+          - not:
+              - uniqueConstraintExists:
+                  tableName: feed_like
+                  constraintName: uk_feed_like_user_feed
+      changes:
+        - addUniqueConstraint:
+            tableName: feed_like
+            columnNames: user_id, feed_id
+            constraintName: uk_feed_like_user_feed
+
+  - changeSet:
+      id: 040-create-index-feed-like-feed-id
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed_like }
+          - columnExists:
+              tableName: feed_like
+              columnName: feed_id
+          - not:
+              - indexExists:
+                  tableName: feed_like
+                  indexName: idx_feed_like_feed_id
+      changes:
+        - createIndex:
+            tableName: feed_like
+            indexName: idx_feed_like_feed_id
+            columns:
+              - column: { name: feed_id }
+
+  - changeSet:
+      id: 041-add-fk-feed-like-user
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed_like }
+          - tableExists: { tableName: user }
+          - columnExists:
+              tableName: feed_like
+              columnName: user_id
+          - not:
+              - foreignKeyConstraintExists:
+                  foreignKeyName: fk_feed_like_user
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: feed_like
+            baseColumnNames: user_id
+            referencedTableName: user
+            referencedColumnNames: id
+            constraintName: fk_feed_like_user
+            onDelete: CASCADE
+            onUpdate: RESTRICT
+
+  - changeSet:
+      id: 042-add-fk-feed-like-feed
+      author: codex
+      preConditions:
+        onFail: MARK_RAN
+        onError: HALT
+        and:
+          - tableExists: { tableName: feed_like }
+          - tableExists: { tableName: feed }
+          - columnExists:
+              tableName: feed_like
+              columnName: feed_id
+          - not:
+              - foreignKeyConstraintExists:
+                  foreignKeyName: fk_feed_like_feed
+      changes:
+        - addForeignKeyConstraint:
+            baseTableName: feed_like
+            baseColumnNames: feed_id
+            referencedTableName: feed
+            referencedColumnNames: id
+            constraintName: fk_feed_like_feed
+            onDelete: CASCADE
+            onUpdate: RESTRICT

--- a/src/test/java/com/yeo_li/yeol_post/domain/feed/controller/FeedControllerTest.java
+++ b/src/test/java/com/yeo_li/yeol_post/domain/feed/controller/FeedControllerTest.java
@@ -1,0 +1,61 @@
+package com.yeo_li.yeol_post.domain.feed.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.yeo_li.yeol_post.domain.feed.service.FeedService;
+import com.yeo_li.yeol_post.global.common.response.ApiResponse;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@ExtendWith(MockitoExtension.class)
+class FeedControllerTest {
+
+    @Mock
+    private FeedService feedService;
+
+    @Mock
+    private OAuth2User principal;
+
+    @InjectMocks
+    private FeedController feedController;
+
+    @Nested
+    class LikeFeedTest {
+
+        @Test
+        void likeFeed_피드아이디가_주어지면_좋아요를_요청하고_성공응답을_반환한다() {
+            // when
+            ResponseEntity<ApiResponse<Void>> response = feedController.likeFeed(principal, 100L);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getIsSuccess()).isTrue();
+            verify(feedService).likeFeed(principal, 100L);
+        }
+    }
+
+    @Nested
+    class UnlikeFeedTest {
+
+        @Test
+        void unlikeFeed_피드아이디가_주어지면_좋아요취소를_요청하고_성공응답을_반환한다() {
+            // when
+            ResponseEntity<ApiResponse<Void>> response = feedController.unlikeFeed(principal, 100L);
+
+            // then
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().getIsSuccess()).isTrue();
+            verify(feedService).unlikeFeed(principal, 100L);
+        }
+    }
+}

--- a/src/test/java/com/yeo_li/yeol_post/domain/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/yeo_li/yeol_post/domain/feed/service/FeedServiceTest.java
@@ -13,6 +13,8 @@ import com.yeo_li.yeol_post.domain.feed.dto.request.FeedUpdateRequest;
 import com.yeo_li.yeol_post.domain.feed.dto.response.FeedResponse;
 import com.yeo_li.yeol_post.domain.feed.entity.Feed;
 import com.yeo_li.yeol_post.domain.feed.exception.FeedExceptionType;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedLikeCount;
+import com.yeo_li.yeol_post.domain.feed.repository.FeedLikeRepository;
 import com.yeo_li.yeol_post.domain.feed.repository.FeedRepository;
 import com.yeo_li.yeol_post.domain.user.domain.Role;
 import com.yeo_li.yeol_post.domain.user.domain.User;
@@ -42,6 +44,9 @@ class FeedServiceTest {
     private FeedRepository feedRepository;
 
     @Mock
+    private FeedLikeRepository feedLikeRepository;
+
+    @Mock
     private OAuth2User principal;
 
     @InjectMocks
@@ -69,8 +74,12 @@ class FeedServiceTest {
                 .extracting(FeedResponse::requiredAccessLevel)
                 .containsExactly(ContentAccessLevel.PUBLIC);
             assertThat(responses.get(0).isOwner()).isFalse();
+            assertThat(responses.get(0).likeCount()).isZero();
+            assertThat(responses.get(0).isLiked()).isFalse();
 
             verify(feedRepository).findAccessibleFeeds(accessLevels);
+            verify(feedLikeRepository).countByFeedIds(List.of(1L));
+            verify(feedLikeRepository, never()).findLikedFeedIds(any(), any());
             verifyNoInteractions(userRepository);
         }
 
@@ -149,6 +158,13 @@ class FeedServiceTest {
             when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
             when(feedRepository.findAccessibleFeeds(accessLevels))
                 .thenReturn(List.of(privateFeed, limitedFeed, publicFeed));
+            when(feedLikeRepository.countByFeedIds(List.of(3L, 2L, 1L)))
+                .thenReturn(List.of(
+                    new FeedLikeCount(2L, 4L),
+                    new FeedLikeCount(3L, 1L)
+                ));
+            when(feedLikeRepository.findLikedFeedIds(10L, List.of(3L, 2L, 1L)))
+                .thenReturn(List.of(3L));
 
             // when
             List<FeedResponse> responses = feedService.getFeeds(principal);
@@ -164,6 +180,12 @@ class FeedServiceTest {
                 );
             assertThat(responses)
                 .extracting(FeedResponse::isOwner)
+                .containsExactly(true, false, false);
+            assertThat(responses)
+                .extracting(FeedResponse::likeCount)
+                .containsExactly(1L, 4L, 0L);
+            assertThat(responses)
+                .extracting(FeedResponse::isLiked)
                 .containsExactly(true, false, false);
 
             verify(feedRepository).findAccessibleFeeds(accessLevels);
@@ -242,6 +264,8 @@ class FeedServiceTest {
             assertThat(response.content()).isEqualTo("오늘의 기록");
             assertThat(response.requiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
             assertThat(response.isOwner()).isTrue();
+            assertThat(response.likeCount()).isZero();
+            assertThat(response.isLiked()).isFalse();
         }
 
         @Test
@@ -356,6 +380,9 @@ class FeedServiceTest {
             when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
             when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
             when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+            when(feedLikeRepository.countByFeedIds(List.of(100L)))
+                .thenReturn(List.of(new FeedLikeCount(100L, 2L)));
+            when(feedLikeRepository.findLikedFeedIds(10L, List.of(100L))).thenReturn(List.of(100L));
 
             // when
             FeedResponse response = feedService.updateFeed(principal, 100L, request);
@@ -368,6 +395,8 @@ class FeedServiceTest {
             assertThat(response.content()).isEqualTo("수정된 피드");
             assertThat(response.requiredAccessLevel()).isEqualTo(ContentAccessLevel.LIMITED);
             assertThat(response.isOwner()).isTrue();
+            assertThat(response.likeCount()).isEqualTo(2L);
+            assertThat(response.isLiked()).isTrue();
         }
 
         @Test
@@ -480,6 +509,97 @@ class FeedServiceTest {
     }
 
     @Nested
+    class LikeFeedTest {
+
+        @Test
+        void likeFeed_접근가능한_피드면_좋아요를_저장한다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PRIVATE);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "좋아요 피드", ContentAccessLevel.LIMITED, author);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when
+            feedService.likeFeed(principal, 100L);
+
+            // then
+            verify(feedLikeRepository).insertIgnore(10L, 100L);
+        }
+
+        @Test
+        void likeFeed_비로그인이면_인증실패_예외를_발생시킨다() {
+            // when & then
+            assertThatThrownBy(() -> feedService.likeFeed(null, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_USER_ID_INVALID));
+            verify(feedRepository, never()).findByIdAndDeletedAtIsNull(100L);
+            verify(feedLikeRepository, never()).insertIgnore(any(), any());
+        }
+
+        @Test
+        void likeFeed_피드가_존재하지않으면_피드없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> feedService.likeFeed(principal, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_NOT_FOUND));
+            verify(feedLikeRepository, never()).insertIgnore(any(), any());
+        }
+
+        @Test
+        void likeFeed_접근권한이_없으면_권한없음_예외를_발생시킨다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.PUBLIC);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "PRIVATE 피드", ContentAccessLevel.PRIVATE, author);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when & then
+            assertThatThrownBy(() -> feedService.likeFeed(principal, 100L))
+                .isInstanceOf(GeneralException.class)
+                .satisfies(ex -> assertThat(((GeneralException) ex).getErrorCode())
+                    .isEqualTo(FeedExceptionType.FEED_FORBIDDEN));
+            verify(feedLikeRepository, never()).insertIgnore(any(), any());
+        }
+    }
+
+    @Nested
+    class UnlikeFeedTest {
+
+        @Test
+        void unlikeFeed_접근가능한_피드면_좋아요를_삭제한다() {
+            // given
+            User viewer = createUser(10L, ContentAccessLevel.LIMITED);
+            User author = createUser(20L, ContentAccessLevel.PUBLIC);
+            Feed feed = createFeed(100L, "좋아요 취소 피드", ContentAccessLevel.LIMITED, author);
+
+            when(principal.getAttributes()).thenReturn(Map.of("userId", 10L));
+            when(userRepository.findById(10L)).thenReturn(Optional.of(viewer));
+            when(feedRepository.findByIdAndDeletedAtIsNull(100L)).thenReturn(Optional.of(feed));
+
+            // when
+            feedService.unlikeFeed(principal, 100L);
+
+            // then
+            verify(feedLikeRepository).deleteByFeedIdAndUserId(100L, 10L);
+        }
+    }
+
+    @Nested
     class DeleteFeedTest {
 
         @Test
@@ -573,4 +693,5 @@ class FeedServiceTest {
         feed.setAuthor(author);
         return feed;
     }
+
 }


### PR DESCRIPTION
## 작업 내용
- `feed_like` 테이블과 `FeedLike` 엔티티/레포지토리를 추가했습니다.
- 피드 좋아요/좋아요 취소 API를 추가했습니다.
  - `POST /api/v1/feeds/{feedId}/likes`
  - `DELETE /api/v1/feeds/{feedId}/likes`
- 피드 목록 응답에 `likeCount`, `isLiked`를 추가했습니다.
- 좋아요 수와 로그인 사용자의 좋아요 여부를 배치 조회로 처리해 N+1 조회를 피했습니다.
- 중복 좋아요는 DB unique 제약과 `INSERT IGNORE`로 idempotent하게 처리했습니다.

## 정책
- 비로그인 사용자는 피드 목록 조회만 가능하며 `isLiked=false`로 응답합니다.
- 좋아요/좋아요 취소는 로그인 사용자만 가능합니다.
- 삭제된 피드나 사용자가 접근할 수 없는 피드에는 좋아요를 변경할 수 없습니다.

## 검증
- `./gradlew test`
- `git diff --check`

Closes #135
